### PR TITLE
🧨 throw `ArgumentException` if dateTime has `DateTimeKind.Unspecified`

### DIFF
--- a/MaKoDateTimeConverter/MaKoDateTimeConverter/MaKoDateTimeConverter.cs
+++ b/MaKoDateTimeConverter/MaKoDateTimeConverter/MaKoDateTimeConverter.cs
@@ -199,7 +199,11 @@ public static class MaKoDateTimeConverter
             throw new ArgumentException("The configuration is invalid", nameof(conversionConfiguration));
         }
 
-        DateTimeOffset result = sourceDateTime;
+        if (sourceDateTime.Kind == DateTimeKind.Unspecified)
+        {
+            throw new ArgumentException($"The kind of the provided datetime must not be unspecified but was {sourceDateTime.Kind}", nameof(sourceDateTime));
+        }
+        DateTimeOffset result = sourceDateTime; // this is an implicit conversion to a Utc DateTime
         if (conversionConfiguration.Source.StripTime)
         {
             result = result.StripTime();

--- a/MaKoDateTimeConverter/MaKoDateTimeConverterTests/MaKoDateTimeConverterTests.cs
+++ b/MaKoDateTimeConverter/MaKoDateTimeConverterTests/MaKoDateTimeConverterTests.cs
@@ -369,4 +369,27 @@ public class MaKoDateTimeConverterTests
         var actual = dt.Convert(conversion);
         actual.Should().Be(expected);
     }
+
+    [Test]
+    public void DateTime_With_Unspecified_Kind_Shall_Raise_ArgumentException()
+    {
+        var unspecifiedDt = new DateTime(2022, 5, 31, 22, 0, 0, DateTimeKind.Unspecified); // smells like utc, but is unspecified
+        var exclusiveToInclusiveEndDateConversion = new DateTimeConversionConfiguration
+        {
+            Source = new DateTimeConfiguration()
+            {
+                IsGas = false,
+                IsEndDate = true,
+                EndDateTimeKind = EndDateTimeKind.Exclusive
+            },
+            Target = new DateTimeConfiguration
+            {
+                IsGas = false,
+                IsEndDate = true,
+                EndDateTimeKind = EndDateTimeKind.Inclusive
+            }
+        };
+        Action conversionOfUnspecifiedDateTime = ()=> unspecifiedDt.Convert(exclusiveToInclusiveEndDateConversion);
+        conversionOfUnspecifiedDateTime.Should().ThrowExactly<ArgumentException>();
+    }
 }

--- a/MaKoDateTimeConverter/MaKoDateTimeConverterTests/MaKoDateTimeConverterTests.cs
+++ b/MaKoDateTimeConverter/MaKoDateTimeConverterTests/MaKoDateTimeConverterTests.cs
@@ -389,7 +389,7 @@ public class MaKoDateTimeConverterTests
                 EndDateTimeKind = EndDateTimeKind.Inclusive
             }
         };
-        Action conversionOfUnspecifiedDateTime = ()=> unspecifiedDt.Convert(exclusiveToInclusiveEndDateConversion);
+        Action conversionOfUnspecifiedDateTime = () => unspecifiedDt.Convert(exclusiveToInclusiveEndDateConversion);
         conversionOfUnspecifiedDateTime.Should().ThrowExactly<ArgumentException>();
     }
 }


### PR DESCRIPTION
> The offset of the resulting [DateTimeOffset](https://learn.microsoft.com/en-us/dotnet/api/system.datetimeoffset) value depends on the [DateTime.Kind](https://learn.microsoft.com/en-us/dotnet/api/system.datetime.kind) property value. If its value is [DateTimeKind.Utc](https://learn.microsoft.com/en-us/dotnet/api/system.datetimekind#system-datetimekind-utc), the offset is set equal to [TimeSpan.Zero](https://learn.microsoft.com/en-us/dotnet/api/system.timespan.zero). If its value is either [DateTimeKind.Local](https://learn.microsoft.com/en-us/dotnet/api/system.datetimekind#system-datetimekind-local) or [DateTimeKind.Unspecified](https://learn.microsoft.com/en-us/dotnet/api/system.datetimekind#system-datetimekind-unspecified), the offset is set equal to that of the local time zone.

https://learn.microsoft.com/en-us/dotnet/standard/datetime/instantiating-a-datetimeoffset-object?source=recommendations#implicit-type-conversion